### PR TITLE
enable support for 2016 servers (i.e. current hydra environment)

### DIFF
--- a/manifests/controls/windows.pp
+++ b/manifests/controls/windows.pp
@@ -1,6 +1,6 @@
 class demo_cis::controls::windows {
   case $::operatingsystemmajrelease {
-    '2012 R2': {
+    '2012 R2', '2016': {
       include ::demo_cis::controls::windows::server2012r2::cis_helpers
       include ::demo_cis::controls::windows::server2012r2::cis_1_1_1
       include ::demo_cis::controls::windows::server2012r2::cis_1_1_2

--- a/manifests/controls/windows.pp
+++ b/manifests/controls/windows.pp
@@ -3,19 +3,19 @@ class demo_cis::controls::windows {
     '2012 R2', '2016': {
       include ::demo_cis::controls::windows::server2012r2::cis_helpers
       include ::demo_cis::controls::windows::server2012r2::cis_1_1_1
-      # include ::demo_cis::controls::windows::server2012r2::cis_1_1_2
-      # include ::demo_cis::controls::windows::server2012r2::cis_1_1_3
-      # include ::demo_cis::controls::windows::server2012r2::cis_1_1_4
-      # include ::demo_cis::controls::windows::server2012r2::cis_1_1_5
-      # include ::demo_cis::controls::windows::server2012r2::cis_1_1_6
-      # include ::demo_cis::controls::windows::server2012r2::cis_9_1_1
-      # include ::demo_cis::controls::windows::server2012r2::cis_9_2_1
-      # include ::demo_cis::controls::windows::server2012r2::cis_9_3_1
-      # include ::demo_cis::controls::windows::server2012r2::cis_17_1_1
-      # include ::demo_cis::controls::windows::server2012r2::cis_17_2_1
-      # include ::demo_cis::controls::windows::server2012r2::cis_17_3_1
-      # include ::demo_cis::controls::windows::server2012r2::cis_17_4_1
-      # include ::demo_cis::controls::windows::server2012r2::cis_17_5_1
+      include ::demo_cis::controls::windows::server2012r2::cis_1_1_2
+      include ::demo_cis::controls::windows::server2012r2::cis_1_1_3
+      include ::demo_cis::controls::windows::server2012r2::cis_1_1_4
+      include ::demo_cis::controls::windows::server2012r2::cis_1_1_5
+      include ::demo_cis::controls::windows::server2012r2::cis_1_1_6
+      include ::demo_cis::controls::windows::server2012r2::cis_9_1_1
+      include ::demo_cis::controls::windows::server2012r2::cis_9_2_1
+      include ::demo_cis::controls::windows::server2012r2::cis_9_3_1
+      include ::demo_cis::controls::windows::server2012r2::cis_17_1_1
+      include ::demo_cis::controls::windows::server2012r2::cis_17_2_1
+      include ::demo_cis::controls::windows::server2012r2::cis_17_3_1
+      include ::demo_cis::controls::windows::server2012r2::cis_17_4_1
+      include ::demo_cis::controls::windows::server2012r2::cis_17_5_1
     }
     default: {}
   }

--- a/manifests/controls/windows.pp
+++ b/manifests/controls/windows.pp
@@ -1,21 +1,21 @@
 class demo_cis::controls::windows {
   case $::operatingsystemmajrelease {
     '2012 R2', '2016': {
-      include ::demo_cis::controls::windows::server2012r2::cis_helpers
-      include ::demo_cis::controls::windows::server2012r2::cis_1_1_1
-      include ::demo_cis::controls::windows::server2012r2::cis_1_1_2
-      include ::demo_cis::controls::windows::server2012r2::cis_1_1_3
-      include ::demo_cis::controls::windows::server2012r2::cis_1_1_4
-      include ::demo_cis::controls::windows::server2012r2::cis_1_1_5
-      include ::demo_cis::controls::windows::server2012r2::cis_1_1_6
-      include ::demo_cis::controls::windows::server2012r2::cis_9_1_1
-      include ::demo_cis::controls::windows::server2012r2::cis_9_2_1
-      include ::demo_cis::controls::windows::server2012r2::cis_9_3_1
-      include ::demo_cis::controls::windows::server2012r2::cis_17_1_1
-      include ::demo_cis::controls::windows::server2012r2::cis_17_2_1
-      include ::demo_cis::controls::windows::server2012r2::cis_17_3_1
-      include ::demo_cis::controls::windows::server2012r2::cis_17_4_1
-      include ::demo_cis::controls::windows::server2012r2::cis_17_5_1
+      # include ::demo_cis::controls::windows::server2012r2::cis_helpers
+      # include ::demo_cis::controls::windows::server2012r2::cis_1_1_1
+      # include ::demo_cis::controls::windows::server2012r2::cis_1_1_2
+      # include ::demo_cis::controls::windows::server2012r2::cis_1_1_3
+      # include ::demo_cis::controls::windows::server2012r2::cis_1_1_4
+      # include ::demo_cis::controls::windows::server2012r2::cis_1_1_5
+      # include ::demo_cis::controls::windows::server2012r2::cis_1_1_6
+      # include ::demo_cis::controls::windows::server2012r2::cis_9_1_1
+      # include ::demo_cis::controls::windows::server2012r2::cis_9_2_1
+      # include ::demo_cis::controls::windows::server2012r2::cis_9_3_1
+      # include ::demo_cis::controls::windows::server2012r2::cis_17_1_1
+      # include ::demo_cis::controls::windows::server2012r2::cis_17_2_1
+      # include ::demo_cis::controls::windows::server2012r2::cis_17_3_1
+      # include ::demo_cis::controls::windows::server2012r2::cis_17_4_1
+      # include ::demo_cis::controls::windows::server2012r2::cis_17_5_1
     }
     default: {}
   }

--- a/manifests/controls/windows.pp
+++ b/manifests/controls/windows.pp
@@ -1,7 +1,7 @@
 class demo_cis::controls::windows {
   case $::operatingsystemmajrelease {
     '2012 R2', '2016': {
-      # include ::demo_cis::controls::windows::server2012r2::cis_helpers
+      include ::demo_cis::controls::windows::server2012r2::cis_helpers
       # include ::demo_cis::controls::windows::server2012r2::cis_1_1_1
       # include ::demo_cis::controls::windows::server2012r2::cis_1_1_2
       # include ::demo_cis::controls::windows::server2012r2::cis_1_1_3

--- a/manifests/controls/windows.pp
+++ b/manifests/controls/windows.pp
@@ -1,6 +1,6 @@
 class demo_cis::controls::windows {
   case $::operatingsystemmajrelease {
-    '2012 R2','2016': {
+    '2012 R2': {
       include ::demo_cis::controls::windows::server2012r2::cis_helpers
       include ::demo_cis::controls::windows::server2012r2::cis_1_1_1
       include ::demo_cis::controls::windows::server2012r2::cis_1_1_2

--- a/manifests/controls/windows.pp
+++ b/manifests/controls/windows.pp
@@ -1,6 +1,6 @@
 class demo_cis::controls::windows {
   case $::operatingsystemmajrelease {
-    '2012 R2': {
+    '2012 R2','2016': {
       include ::demo_cis::controls::windows::server2012r2::cis_helpers
       include ::demo_cis::controls::windows::server2012r2::cis_1_1_1
       include ::demo_cis::controls::windows::server2012r2::cis_1_1_2

--- a/manifests/controls/windows.pp
+++ b/manifests/controls/windows.pp
@@ -2,7 +2,7 @@ class demo_cis::controls::windows {
   case $::operatingsystemmajrelease {
     '2012 R2', '2016': {
       include ::demo_cis::controls::windows::server2012r2::cis_helpers
-      # include ::demo_cis::controls::windows::server2012r2::cis_1_1_1
+      include ::demo_cis::controls::windows::server2012r2::cis_1_1_1
       # include ::demo_cis::controls::windows::server2012r2::cis_1_1_2
       # include ::demo_cis::controls::windows::server2012r2::cis_1_1_3
       # include ::demo_cis::controls::windows::server2012r2::cis_1_1_4

--- a/manifests/controls/windows/server2012r2/cis_1_1_5.pp
+++ b/manifests/controls/windows/server2012r2/cis_1_1_5.pp
@@ -2,7 +2,7 @@ class demo_cis::controls::windows::server2012r2::cis_1_1_5 {
 
   local_security_policy{ 'Password must meet complexity requirements':
     ensure       => present,
-    policy_value => '1',
+    policy_value => 'enabled',
   }
 
 }

--- a/manifests/controls/windows/server2012r2/cis_1_1_6.pp
+++ b/manifests/controls/windows/server2012r2/cis_1_1_6.pp
@@ -2,7 +2,7 @@ class demo_cis::controls::windows::server2012r2::cis_1_1_6 {
 
   local_security_policy{ 'Store passwords using reversible encryption':
     ensure       => present,
-    policy_value => '0',
+    policy_value => 'disabled',
   }
 
 }


### PR DESCRIPTION
updated so that it will run on 2016 servers. Note this needs the updated kpn-local-security policy module and the actpol(?) module from Fervid needs to be available in the Puppetfile (currently it is commented out in the control-repo for hydra).